### PR TITLE
WebSocketClientError 추가 및 assert문을 raise로 대체

### DIFF
--- a/worker/modules/web_socket_client.py
+++ b/worker/modules/web_socket_client.py
@@ -207,15 +207,23 @@ class WebSocketClient:
         # INFO_QUERY: searchAccountByPattern -> fetchMultiAccountBrief
         self.log('Send SearchAccountByPattern')
         response = await self.send_searchaccountbypattern_msg(fid)
-        assert response['decode_id'] != 0, 'No account found'
+
+        user_info = {
+            "fid": fid
+        }
+
+        if response['decode_id'] == 0:
+            raise WebSocketClientFindUserError('No account found', self.login_info, user_info)
         uid = response['decode_id']
+        user_info['uid'] = uid
         self.log('Done SearchAccountByPattern: decode_id = ' + str(uid))
 
         self.log('Send FetchMultiAccountBrief')
         response = await self.send_fetchmultiaccountbrief_msg(uid)
-        assert 'players' in response, 'No user information found'
-        self.log('Done FetchMultiAccountBrief: user information ↓')
 
+        if 'players' not in response.keys():
+            raise WebSocketClientFindUserError('No user information found', self.login_info, user_info)
+        self.log('Done FetchMultiAccountBrief: user information ↓')
 
         info = response['players'][0]
         self.log(str(info))

--- a/worker/modules/web_socket_client.py
+++ b/worker/modules/web_socket_client.py
@@ -12,6 +12,22 @@ import threading
 import getData
 
 
+class WebSocketClientError(Exception):
+    def __init__(
+        self, message: str, is_critical: bool, data: dict | None, *args: object
+    ):
+        super().__init__(*args)
+        self.message: str = message
+        self.is_critical: bool = is_critical
+        self.data: dict = data if data is not None else {}
+
+    def __str__(self) -> str:
+        return self.message
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+
 class WebSocketClient:
     class HeatbeatTimer:
         def __init__(self, func, log):

--- a/worker/modules/web_socket_client.py
+++ b/worker/modules/web_socket_client.py
@@ -72,7 +72,8 @@ class WebSocketClient:
         self.index = 1
         self.lock = threading.Lock()
 
-        assert not os.path.isfile('.ws_client.lock'), 'Other instance already running...'
+        if os.path.isfile(".ws_client.lock"):
+            raise WebSocketClientInitError("Other instance already running...")
 
         self.file = open('.ws_client.lock', 'w')
 

--- a/worker/modules/web_socket_client.py
+++ b/worker/modules/web_socket_client.py
@@ -28,6 +28,23 @@ class WebSocketClientError(Exception):
         return self.data[key]
 
 
+class WebSocketClientInitError(WebSocketClientError):
+    def __init__(self, message: str, *args: object):
+        super().__init__(message, True, None, *args)
+
+
+class WebSocketClientLoginError(WebSocketClientError):
+    def __init__(self, message: str, login_info: dict, *args: object):
+        super().__init__(message, True, {"login_info": login_info}, *args)
+
+
+class WebSocketClientFindUserError(WebSocketClientError):
+    def __init__(self, message: str, login_info: dict, user_info: dict, *args: object):
+        super().__init__(
+            message, False, {"login_info": login_info, "user_info": user_info}, *args
+        )
+
+
 class WebSocketClient:
     class HeatbeatTimer:
         def __init__(self, func, log):


### PR DESCRIPTION
websocket client 자체 코드에서 발생할 수 있는 오류를 담는 기초 클래스 `WebSocketClientError` 추가. 이 클래스를 상속받는 클래스는 총 3가지로,

- `WebSocketClientInitError`: `WebSocketClient`의 인스턴스 생성 과정에서 발생하는 오류.
  - `e.message`: 에러 메시지
    - Other instance already running...

- `WebSocketClientLoginError`: `WebSocketClient`의 로그인 과정에서 발생하는 오류.
  - `e.message`: 에러 메시지
    - Oauth2Auth Failed
    - Oauth2Check Failed
    - No account found with given uid
    - Oauth2Login Failed
  - `e["login_info"]`: 로그인 시 사용한 데이터(dict)

- `WebSocketClientLoginError`: `WebSocketClient`의 유저 검색 과정에서 발생하는 오류.
  - `e.message`: 에러 메시지
    - No account found
    - No user information found
  - `e["login_info"]`: 로그인 시 사용한 데이터(dict)
  - `e["user_info"]`: 유저 검색에 사용한 데이터(dict)