### PR TITLE
Use enum `WebSocketClient.TargetServer` instead of global variable `LANG`

### DIFF
--- a/worker/wspkg/web_socket_client.py
+++ b/worker/wspkg/web_socket_client.py
@@ -6,6 +6,7 @@ import os
 import uuid
 import logging
 import threading
+import sys
 from typing import Dict, Union
 from enum import StrEnum
 
@@ -271,9 +272,15 @@ class WebSocketClient:
 async def main():
     print("----- Manual Mode -----")
     print("Enter fid to find user, leave blank to quit")
+
     try:
-        uid = os.getenv("_".join(["ronnya_uid", LANG]))
-        token = os.getenv("_".join(["ronnya_token", LANG]))
+        server = WebSocketClient.TargetServer(sys.argv[1] if len(sys.argv) > 1 else "jp")
+    except:
+        server = WebSocketClient.TargetServer.JP
+
+    try:
+        uid = os.getenv("_".join(["ronnya_uid", server]))
+        token = os.getenv("_".join(["ronnya_token", server]))
 
         client = WebSocketClient()
         print("Intialize connection")

--- a/worker/wspkg/web_socket_client.py
+++ b/worker/wspkg/web_socket_client.py
@@ -20,7 +20,6 @@ from . import lq_proto_pb2
 # import lq_proto_pb2
 # import getData
 #############################################################
-LANG = "jp"
 
 
 class WebSocketClientError(Exception):
@@ -84,7 +83,8 @@ class WebSocketClient:
         JP = "jp"
         US = "us"
 
-    def __init__(self):
+    def __init__(self, server: TargetServer = TargetServer.JP):
+        self.server = server
         self.index = 1
         self.lock = threading.Lock()
 
@@ -95,7 +95,7 @@ class WebSocketClient:
 
     async def connect(self):
         self.client = await websockets.connect(
-            os.getenv("_".join(["ws_server_addr", LANG]))
+            os.getenv("_".join(["ws_server_addr_", self.server.value]))
         )
         self.ht = WebSocketClient.HeatbeatTimer(self.send_heatbeat, self.log)
         self.ht.start()

--- a/worker/wspkg/web_socket_client.py
+++ b/worker/wspkg/web_socket_client.py
@@ -7,6 +7,7 @@ import uuid
 import logging
 import threading
 from typing import Dict, Union
+from enum import StrEnum
 
 #############################################################
 #default
@@ -78,6 +79,10 @@ class WebSocketClient:
                 await asyncio.sleep(360)
                 await self.func()
                 self.log("Heatbeat sent\n> ", end="")
+
+    class TargetServer(StrEnum):
+        JP = "jp"
+        US = "us"
 
     def __init__(self):
         self.index = 1


### PR DESCRIPTION
~~ㅈㄱㄴ~~

`WebSocketClient` 클래스 내부에 `TargetServer` enum을 생성하여 worker에서 인스턴스를 생성하면서 서버를 선택할 수 있도록 수정. 현재 존재하는 값은

- `JP` (=`"jp"`): 일본 서버
- `US` (=`"us"`): 글로벌 서버

인스턴스 생성 시 parameter로 서버를 제공해야 함, 기본값은 일본 서버