### PR TITLE
flask 주소 selector 변경, flask에 protobuf 활용 코드 추가

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -17,6 +17,7 @@ import os
 import datetime
 
 from dbpkg.ronnyaDB import RonnyaDB
+from proto import message_util
 
 if not os.environ.get('IN_CONTAINER'):
     from dotenv import load_dotenv
@@ -42,12 +43,13 @@ def handle_fid(server, fid):
             current_data.pop("uid")
             return current_data
 
-    client.send_string(str(fid)) # TODO: 서버 정보 추가해서 보내기
+    msg = message_util.wrap_request(fid, server) # TODO: test needed
+    client.send_string(msg)
+
     if (client.poll(REQUEST_TIMEOUT) & zmq.POLLIN) != 0: #정보 수신
         reply = client.recv()
 
-        # TODO: reply를 dict 형태의 result로 변환하는 과정
-
+        result = message_util.unwrap_response(reply) # TODO: test needed
         result = RonnyaDB.ws_to_db(result)
         ronnyadb.update_data(fid, result, server)
         result.pop("uid")

--- a/client/client.py
+++ b/client/client.py
@@ -25,10 +25,11 @@ if not os.environ.get('IN_CONTAINER'):
 
 ZMQ_ROUTER_FRONT = os.getenv("ZMQ_ROUTER_FRONT")
 REQUEST_TIMEOUT = 3000
+SERVERS = ["jp", "us"]
 
 app = Flask(__name__)
 
-@app.route('/request/<server>/<fid>')
+@app.route("/request/<any(" + ",".join(SERVERS) + "):server>/<fid>")
 def handle_fid(server, fid):
     '''
     fid를 받아서 zmq통신 후 결과 반환


### PR DESCRIPTION
`any` selector 활용하여 서버는 `jp`, `us`로 한정
protobuf 관련 기능은 추후 테스트 필요